### PR TITLE
Support tags

### DIFF
--- a/lib/autostacker24/tests.rb
+++ b/lib/autostacker24/tests.rb
@@ -92,6 +92,11 @@ def add_tags
          "Type": "UnsupportedType",
          "Properties": {
          }
+       },
+       "ASGType_ReturnsTagsWithPropagateAtLaunch" : {
+         "Type": "AWS::AutoScaling::AutoScalingGroup",
+         "Properties": {
+         }
        }
      }
    }
@@ -111,7 +116,7 @@ if $0 ==__FILE__ # placeholder for interactive testing
 
   #remove_comments
   #replace_variables
-  merge_tags
-  #add_tags
+  #merge_tags
+  add_tags
 
 end

--- a/lib/autostacker24/tests.rb
+++ b/lib/autostacker24/tests.rb
@@ -36,6 +36,73 @@ def replace_variables
    puts Stacker.template_body(template)
 end
 
+
+def merge_tags
+  template = <<-EOF
+   // AutoStacker24
+   {
+     "Resources" : {
+       "Loadbalancer" : {
+         "Type": "AWS::ElasticLoadBalancing::LoadBalancer",
+         "SomethingElse": {
+           "x": "y"
+         },
+         "Properties": {
+           "Tags" : [
+             {"Key" : "Environment", "Value" : "@AWS::StackName","PropagateAtLaunch": "true" }
+           ]
+         }
+       }
+     }
+   }
+   EOF
+
+   puts Stacker.template_body(template, [{"Key": "MyKey", "Value": "MyValue"}])
+   puts Stacker.template_body(template, [{"Key"=> "MyKey", "Value" => "MyValue"}])
+end
+
+def add_tags
+  template = <<-EOF
+   // AutoStacker24
+   {
+     "Resources" : {
+       "supportedTypeNoTags_returnsTwoTags" : {
+         "Type": "AWS::ElasticLoadBalancing::LoadBalancer",
+         "Properties": {
+         }
+       },
+       "supportedTypeNonConflictingTags_returnsThreeTags" : {
+         "Type": "AWS::ElasticLoadBalancing::LoadBalancer",
+         "Properties": {
+           "Tags" : [
+             {"Key" : "UniqueKey", "Value" : "SomeValue"}
+           ]
+         }
+       },
+       "supportedTypeTwoConflictingTags_ReturnsThreeTagsOverwritten" : {
+         "Type": "AWS::ElasticLoadBalancing::LoadBalancer",
+         "Properties": {
+           "Tags" : [
+             {"Key" : "Team", "Value" : "Old"},
+             {"Key" : "Service", "Value" : "Dashing"}
+           ]
+         }
+       },
+       "unsupportedType_ReturnsNoTags" : {
+         "Type": "UnsupportedType",
+         "Properties": {
+         }
+       }
+     }
+   }
+   EOF
+
+   tags = [{"Key" => "Team", "Value" => "Kondor"}, {"Key" => "Team2", "Value" => "Kondor2"}]
+  #  puts AutoStacker24::Preprocessor.tokenize('content').inspect
+  #  puts AutoStacker24::Preprocessor.tokenize('bla @@@var2 @bla2 xyz').inspect
+   puts Stacker.template_body(template, tags)
+end
+
 if $0 ==__FILE__ # placeholder for interactive testing
   $stderr.sync=true
   $stdout.sync=true
@@ -43,6 +110,8 @@ if $0 ==__FILE__ # placeholder for interactive testing
   #OpenSSL::SSL::VERIFY_PEER = OpenSSL::SSL::VERIFY_NONE # Windows Hack
 
   #remove_comments
-  replace_variables
+  #replace_variables
+  merge_tags
+  #add_tags
 
 end

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ especially if you have lots of parameters or dependencies between other stacks.
 
 ## Create or Update
 ```ruby
-Stacker.create_or_update_stack(stack_name, template, parameters, parent_stack_name = nil)
+Stacker.create_or_update_stack(stack_name, template, parameters, parent_stack_name = nil, tags = nil)
 ```
 Creates or updates the stack depending if it exists or not.
 It will also wait until the stack operation is eventually finished, handling all status checks for you.
@@ -20,6 +20,7 @@ It will also wait until the stack operation is eventually finished, handling all
   - `parent_stack_name`: this special feature will read the output parameters of an existing stack and
     merge them to the given parameters. Therefore the new stack can easily reference resources
     (e.g. VPC Ids or Security Groups) from a parent stack.
+  - `tags`: Key-value pairs to associate with this stack. As CloudFormation [does not support updating tags](http://docs.aws.amazon.com/cli/latest/reference/cloudformation/update-stack.html) AutoStacker24 is injecting the tags to all  `Resources` elements which support it.
 
 Example:
 
@@ -30,7 +31,11 @@ params = {
   AmiId:           "ami-4711"
 }
 
-Stacker.create_or_update_stack('my-stack, 'service-stack.json', params)
+tags = [
+  { "Key": "Team", "Value": "Kondor"}
+]
+
+Stacker.create_or_update_stack('my-stack', 'service-stack.json', params, tags)
 ```
 
 For finer control Stacker offers also
@@ -45,7 +50,7 @@ For finer control Stacker offers also
 
 ## Template Preprocessing
 
-1. You can put javascript like comments in jour template, even if they are are illegal in pure json.
+1. You can put javascript like comments in your template, even if they are are illegal in pure json.
    Nevertheless, sometimes it's just handy to have the ability to quickly comment some parts out.
    AutoStacker24 will remove all comments before passing the template to AWS.
 


### PR DESCRIPTION
As CloudFormation does not support updating tags this workaround will inject the tags automatically to all Resources elements which support tags. 
