### PR TITLE
Helpful message on invalid json

### DIFF
--- a/lib/autostacker24/template_preprocessor.rb
+++ b/lib/autostacker24/template_preprocessor.rb
@@ -94,8 +94,6 @@ module AutoStacker24
         json.map{|v| preprocess_json(v)}
       elsif json.is_a?(String)
         preprocess_string(json)
-      elsif json.is_a?(Fixnum) # workaround for issue https://github.com/flori/json/issues/269
-        json.to_f
       else
         json
       end

--- a/lib/autostacker24/tests.rb
+++ b/lib/autostacker24/tests.rb
@@ -57,7 +57,6 @@ def merge_tags
    }
    EOF
 
-   puts Stacker.template_body(template, [{"Key": "MyKey", "Value": "MyValue"}])
    puts Stacker.template_body(template, [{"Key"=> "MyKey", "Value" => "MyValue"}])
 end
 


### PR DESCRIPTION
If you have a syntax error in the json template the error message from the optimized C-parser is not very helpful. By falling back to the pure ruby parser in case of errors you get a better error message that gives a least some hints of the cause.