### PR TITLE
Syntax helper for Fn::FindInMap

### DIFF
--- a/lib/autostacker24/template_preprocessor.rb
+++ b/lib/autostacker24/template_preprocessor.rb
@@ -78,10 +78,15 @@ module AutoStacker24
       m1 = m[1]
       m2 = m[3]
       m3 = m[5]
-      if m3
-        {'Fn::FindInMap' => [m1, preprocess_string(m2), m3]}
-      elsif m2
-        {'Fn::FindInMap' => [m1 + 'Map', preprocess_string('@' + m1), m2]}
+      if m2
+        args = if m3
+                  [m1, m2, m3]
+               elsif m1 =~ /Map$/
+                 [m1, '@' + m1[0..-4], m2]
+               else
+                 [m1 + 'Map', '@' + m1, m2]
+               end
+        {'Fn::FindInMap' => [args[0], preprocess_string(args[1]), preprocess_string(args[2])]}
       else
         {'Ref' => m1}
       end

--- a/lib/autostacker24/template_preprocessor.rb
+++ b/lib/autostacker24/template_preprocessor.rb
@@ -81,8 +81,6 @@ module AutoStacker24
       if m2
         args = if m3
                   [m1, m2, m3]
-               elsif m1 =~ /Map$/
-                 [m1, '@' + m1[0..-4], m2]
                else
                  [m1 + 'Map', '@' + m1, m2]
                end

--- a/readme.md
+++ b/readme.md
@@ -64,18 +64,22 @@ For finer control Stacker offers also
 3. For the "UserData" property you can reference a file `@file://./myscript.sh` that gets
    auto encoded to base64. If you pass a simple string that gets autoencoded.
 
+4. Instead of using Fn::FindInMap you can do something like `@EnvironmentMap[@Environment, Key]`
+
   instead of  | just write
   ------------- | -------------
   `"prop": {"Ref": "myVar"}` | `"prop": "@myVar"`
   `"prop": {"Fn::Join":["-",[`<br/>`{"Ref":"AWS::StackName"},{"Ref":"tableName"},"test"`<br/>`]]}`|`"prop": "@AWS::StackName-@tableName-test"`
   `"prop": "bla@hullebulle.org"` | `"prop": "bla@@hullebulle.org"`
-  `"UserData": {"Fn:Base": ... }` | `"UserData": "@file://./myscript.sh"`
+  `"UserData": {"Fn:Base64": ... }` | `"UserData": "@file://./myscript.sh"`
+  `"prop": {"Fn::FindInMap": ["RegionMap", { "Ref" : "AWS::Region" }, "32"]` | `"@RegionMap[@Region, 32]"` or `"@Region[32]`
+
 
 By default, AutoStacker24 don't preprocess templates. If you want to use this functionality
 your template must start with a comment:
 
 ```javascript
-// AutoStacker24
+// AutoStacker24 -x:MapConvention
 {
   ...
 }

--- a/readme.md
+++ b/readme.md
@@ -79,7 +79,7 @@ By default, AutoStacker24 don't preprocess templates. If you want to use this fu
 your template must start with a comment:
 
 ```javascript
-// AutoStacker24 -x:MapConvention
+// AutoStacker24
 {
   ...
 }

--- a/spec/templating_spec.rb
+++ b/spec/templating_spec.rb
@@ -27,7 +27,8 @@ RSpec.describe 'Stacker Template Processing' do
         "UserData": {"Fn::Base64": "#!/bin/bash"}
       },
       "find_in_map": "@EnvMap[@Env, Key]",
-      "find_in_map_convention": "@Env[Key]"
+      "find_in_map_convention": "@Env[Key]",
+      "find_in_map_convention2": "@EnvMap[Key]"
     }
     EOL
   end
@@ -42,6 +43,11 @@ RSpec.describe 'Stacker Template Processing' do
   it 'generates Fn:FindInMap elements by convention' do
     expected = { 'Fn::FindInMap' => ['EnvMap', { 'Ref' => 'Env' }, 'Key'] }
     expect(parsed_template['find_in_map_convention']).to eq(expected)
+  end
+
+  it 'generates Fn:FindInMap elements by convention2' do
+    expected = { 'Fn::FindInMap' => ['EnvMap', { 'Ref' => 'Env' }, 'Key'] }
+    expect(parsed_template['find_in_map_convention2']).to eq(expected)
   end
 
   it 'removes any comments into valid json' do

--- a/spec/templating_spec.rb
+++ b/spec/templating_spec.rb
@@ -9,10 +9,7 @@ RSpec.describe 'Stacker Template Processing' do
       "bla": "bla", //comment
       "fasel": "//no comment",
       "blub": // still a "comment"
-      "some string" // comment
-      /*
-        a longer multiline comment
-      */ ,
+      "some string", // comment
       "single": "@var1",
       "embedded": "bla @var2 @bla2",
       "array": ["@var2", "@var3"],

--- a/spec/templating_spec.rb
+++ b/spec/templating_spec.rb
@@ -25,12 +25,24 @@ RSpec.describe 'Stacker Template Processing' do
       },
       "already_encoded": {
         "UserData": {"Fn::Base64": "#!/bin/bash"}
-      }
+      },
+      "find_in_map": "@EnvMap[@Env, Key]",
+      "find_in_map_convention": "@Env[Key]"
     }
     EOL
   end
 
   subject(:parsed_template) { JSON.parse(Stacker.template_body(template)) }
+
+  it 'generates Fn:FindInMap elements' do
+    expected = { 'Fn::FindInMap' => ['EnvMap', { 'Ref' => 'Env' }, 'Key'] }
+    expect(parsed_template['find_in_map']).to eq(expected)
+  end
+
+  it 'generates Fn:FindInMap elements by convention' do
+    expected = { 'Fn::FindInMap' => ['EnvMap', { 'Ref' => 'Env' }, 'Key'] }
+    expect(parsed_template['find_in_map_convention']).to eq(expected)
+  end
 
   it 'removes any comments into valid json' do
     begin

--- a/spec/templating_spec.rb
+++ b/spec/templating_spec.rb
@@ -30,8 +30,7 @@ RSpec.describe 'Stacker Template Processing' do
         "UserData": {"Fn::Base64": "#!/bin/bash"}
       },
       "find_in_map": "@EnvMap[@Env, Key]",
-      "find_in_map_convention": "@Env[Key]",
-      "find_in_map_convention2": "@EnvMap[Key]"
+      "find_in_map_convention": "@Env[Key]"
     }
     EOL
   end
@@ -46,11 +45,6 @@ RSpec.describe 'Stacker Template Processing' do
   it 'generates Fn:FindInMap elements by convention' do
     expected = { 'Fn::FindInMap' => ['EnvMap', { 'Ref' => 'Env' }, 'Key'] }
     expect(parsed_template['find_in_map_convention']).to eq(expected)
-  end
-
-  it 'generates Fn:FindInMap elements by convention2' do
-    expected = { 'Fn::FindInMap' => ['EnvMap', { 'Ref' => 'Env' }, 'Key'] }
-    expect(parsed_template['find_in_map_convention2']).to eq(expected)
   end
 
   it 'removes any comments into valid json' do

--- a/spec/templating_spec.rb
+++ b/spec/templating_spec.rb
@@ -9,7 +9,10 @@ RSpec.describe 'Stacker Template Processing' do
       "bla": "bla", //comment
       "fasel": "//no comment",
       "blub": // still a "comment"
-      "some string", // comment
+      "some string" // comment
+      /*
+        a longer multiline comment
+      */ ,
       "single": "@var1",
       "embedded": "bla @var2 @bla2",
       "array": ["@var2", "@var3"],


### PR DESCRIPTION
This is an implementation for my proposal in #10 
Implementation is straight forward and handles all proposed variants.
It is not perfect, as it doesn't handle nested maps, e.g. `@Environment[@AnotherMap[Key,Property], RealProperty]`. For all my use cases the flat lookup is sufficient so I would like to invite you to experiment with the simple map lookup.