### PR TITLE
Remove removing of comments

### DIFF
--- a/lib/autostacker24/template_preprocessor.rb
+++ b/lib/autostacker24/template_preprocessor.rb
@@ -14,7 +14,6 @@ module AutoStacker24
     end
 
     def self.parse_json(template)
-      template = template.gsub(/(\s*\/\/.*$)|(".*")/) {|m| m[0] == '"' ? m : ''} # replace comments
       JSON(template)
     rescue JSON::ParserError => e
       require 'json/pure' # pure ruby parser has better error diagnostics

--- a/spec/templating_spec.rb
+++ b/spec/templating_spec.rb
@@ -9,10 +9,7 @@ RSpec.describe 'Stacker Template Processing' do
       "bla": "bla", //comment
       "fasel": "//no comment",
       "blub": // still a "comment"
-      "some string" // comment
-      /*
-        a longer multiline comment
-      */ ,
+      "some string", // comment
       "single": "@var1",
       "embedded": "bla @var2 @bla2",
       "array": ["@var2", "@var3"],


### PR DESCRIPTION
It looks like the standard json parser is removing simple and multi-line comments. So you could remove the regex that removes simple comments and rely completely on the ruby JSON parser to remove the comments. Alternatively you could remove the multiline comment from the template_spec.rb so we have the possibility to use a strict JSON parser that throws on comments. 
https://groups.yahoo.com/neo/groups/json/conversations/topics/152
What do you think?