### PR TITLE
Improve Command Line Tool

### DIFF
--- a/bin/autostacker24
+++ b/bin/autostacker24
@@ -48,6 +48,8 @@ end
 
 error("one command expected, found #{ARGV.size}") if ARGV.size != 1
 args.command = ARGV[0]
+args.params = args.params.inject({}){|m, kv| m.merge(Hash[kv[0].to_sym, kv[1]])}
+
 Stacker.region = args.region
 Stacker.credentials = Aws::SharedCredentials(profile_name: args.profile) if args.profile
 

--- a/bin/autostacker24
+++ b/bin/autostacker24
@@ -3,23 +3,69 @@
 require 'optparse'
 require 'autostacker24'
 
-def parse_options(argv)
-  params = {}
-  parser = OptionParser.new
-  parser.on("--template VALUE", "template location") do |value|
-    params[:template] = value 
-  end
-  parser.parse(argv)
-  return params
+def error(msg)
+  puts "\nError: #{msg}\n\n#{USAGE}"
+  exit 1
 end
 
-command = ARGV[0]
-params = parse_options(ARGV)
-
-if command == "validate"
-  Stacker.validate_template(params[:template])
-elsif command == "preprocess"
-  puts Stacker.template_body(params[:template])
-else
-  raise ArgumentError, "unknown command"
+def check_template(args)
+  error('--template missing or file not found') unless args.template && File.exists?(args.template)
 end
+
+def check_stack(args)
+  error('--stack name missing') unless args.stack
+end
+
+args = OpenStruct.new
+args.region = ENV['AWS_REGION']
+args.params = {}
+parser = OptionParser.new do |opts|
+  opts.banner = 'Usage: autostacker24 command [options]'
+  opts.separator ''
+  opts.separator 'Commands:'
+  opts.separator "\tcreate\t\t create or update a stack"
+  opts.separator "\tdelete\t\t delete a stack"
+  opts.separator "\tpreprocess\t pretty print template after preprocessing"
+  opts.separator "\tvalidate\t validate the template"
+  opts.separator ''
+  opts.separator 'Options:'
+  opts.on('--template TEMPLATE', 'Path to template')                {|v| args.template = v}
+  opts.on('--stack STACK',       'Name of stack')                   {|v| args.stack = v}
+  opts.on('--parent PARENT',     'Name of parent stack')            {|v| args.parent = v}
+  opts.on('--region REGION',     'AWS region')                      {|v| args.region = v}
+  opts.on('--profile PROFILE',   'AWS profile (use aws configure)') {|v| args.profile = v}
+  opts.on('--param KEY=VALUE',   'Stack Parameter')                 {|v| args.params.store(*v.split('=')) }
+  opts.on('--help',              'Show this help')                  {|_| puts opts; exit!;}
+  opts.on('--version',           'Show version')                    {|_| puts `gem list autostacker24`; exit!;}
+end
+USAGE = parser.to_s
+
+begin
+  parser.parse!(ARGV)
+rescue OptionParser::ParseError => x
+  error(x)
+end
+
+error("one command expected, found #{ARGV.size}") if ARGV.size != 1
+args.command = ARGV[0]
+Stacker.region = args.region
+Stacker.credentials = Aws::SharedCredentials(profile_name: args.profile) if args.profile
+
+case args.command
+  when /validate/
+    check_template(args)
+    Stacker.validate_template(args.template)
+  when /create|update|create_or_update/
+    check_template(args)
+    check_stack(args)
+    Stacker.create_or_update_stack(args.stack, args.template, args.params, args.parent)
+  when /delete/
+    check_stack(args)
+    Stacker.delete_stack(args.stack)
+  when /preprocess|show/
+    check_template(args)
+    puts JSON.pretty_generate(JSON.parse(Stacker.template_body(args.template)))
+  else
+    error("unknown command '#{args.command}'")
+end
+

--- a/lib/autostacker24/stacker.rb
+++ b/lib/autostacker24/stacker.rb
@@ -63,6 +63,7 @@ module Stacker
   # finally, if mandatory parameters are missing, an error will be raised
   def merge_and_validate(template, parameters, stack_name)
     valid = validate_template(template).parameters
+    parameters = transform_parameters(parameters)
     if stack_name
       present = valid.map{|p| p.parameter_key.to_sym}
       get_stack_output(stack_name).each do |key, value|
@@ -147,6 +148,10 @@ module Stacker
     transform_output(stack.outputs).freeze
   end
 
+  def transform_parameters(parameters)
+    parameters.inject({}){|m, kv| m.merge(Hash[kv[0].to_sym, kv[1]])}
+  end
+
   def transform_output(output)
     output.inject({}) { |m, o| m.merge(o.output_key.to_sym => o.output_value) }
   end
@@ -162,7 +167,7 @@ module Stacker
   end
 
   def get_stack_events(stack_name_or_id)
-    events = cloud_formation.describe_stack_events(stack_name: stack_name_or_id).data.stack_events
+    cloud_formation.describe_stack_events(stack_name: stack_name_or_id).data.stack_events
   end
 
   def cloud_formation # lazy CloudFormation client

--- a/lib/autostacker24/stacker.rb
+++ b/lib/autostacker24/stacker.rb
@@ -63,7 +63,6 @@ module Stacker
   # finally, if mandatory parameters are missing, an error will be raised
   def merge_and_validate(template, parameters, stack_name)
     valid = validate_template(template).parameters
-    parameters = transform_parameters(parameters)
     if stack_name
       present = valid.map{|p| p.parameter_key.to_sym}
       get_stack_output(stack_name).each do |key, value|
@@ -146,10 +145,6 @@ module Stacker
     stack = find_stack(stack_name)
     raise "stack #{stack_name} not found" unless stack
     transform_output(stack.outputs).freeze
-  end
-
-  def transform_parameters(parameters)
-    parameters.inject({}){|m, kv| m.merge(Hash[kv[0].to_sym, kv[1]])}
   end
 
   def transform_output(output)


### PR DESCRIPTION
I like the command line version so I decided to enhance it a little bit:

- the preprocess template command now pretty prints the json to be more usable
- add create and delete commands
- add a few options necessary for commands

```
Usage: autostacker24 command [options]

Commands:
        create           create or update a stack
        delete           delete a stack
        preprocess       pretty print template after preprocessing
        validate         validate the template

Options:
        --template TEMPLATE          Path to template
        --stack STACK                Name of stack
        --parent PARENT              Name of parent stack
        --region REGION              AWS region
        --profile PROFILE            AWS profile (use aws configure)
        --param KEY=VALUE            Stack Parameter
        --help                       Show this help
        --version                    Show version
```
