### PR TITLE
Support yaml templates

### DIFF
--- a/examples/yaml-stack.md
+++ b/examples/yaml-stack.md
@@ -23,7 +23,7 @@ Parameters:
     Default: arn:aws:iam::1234567800:instance-profile/Service
   BastionSSH:
     Type: String
-    Default: sg-12345678
+    Default: sg-12345678 # You can put comments here
 Mappings:
   EnvironmentMap:
     Staging:

--- a/examples/yaml-stack.md
+++ b/examples/yaml-stack.md
@@ -1,0 +1,146 @@
+## Example YAML Template
+Not that in YAML `@` is a reserved character so if it is the first character
+in a string you have to quote the string.
+
+```yaml
+# AutoStacker24 YAML CloudFormation Template
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Example WebService Stack
+Parameters:
+  Environment:
+    Type: String
+    AllowedValues:
+    - Staging
+    - Production
+  Version:
+    Type: String
+    Default: latest
+  ImageId:
+    Type: String
+    Default: ami-12345678
+  InstanceProfile:
+    Type: String
+    Default: arn:aws:iam::1234567800:instance-profile/Service
+  BastionSSH:
+    Type: String
+    Default: sg-12345678
+Mappings:
+  EnvironmentMap:
+    Staging:
+      AvailabilityZones:
+      - eu-west-1a
+      Subnets:
+      - subnet-80907060
+      InstanceType: t2.small
+      InstanceSecurityGroup: sg-87654321
+      ELBSecurityGroup: sg-abcdef00
+      DomainName: ci-service.myorg.net
+    Production:
+      AvailabilityZones:
+      - eu-west-1b
+      Subnets:
+      - subnet-60607060
+      InstanceType: t2.small
+      InstanceSecurityGroup: sg-ab23ab45
+      ELBSecurityGroup: sg-00abcdef
+      DomainName: service.myorg.net
+Resources:
+  LaunchConfig:
+    Type: AWS::AutoScaling::LaunchConfiguration
+    Properties:
+      AssociatePublicIpAddress: true
+      EbsOptimized: false
+      IamInstanceProfile: "@InstanceProfile"
+      ImageId: "@ImageId"
+      InstanceMonitoring: false
+      InstanceType: "@Environment[InstanceType]"
+      KeyName: instance_key
+      SecurityGroups:
+      - "@Environment[InstanceSecurityGroup]"
+      - "@BastionSSH"
+      UserData: |
+        #!/bin/bash -xe
+        aws ecr get-login --region us-east-1 | /bin/bash
+        docker run -d --restart=always -e ENVIRONMENT=@Environment 1234567800.dkr.ecr.us-east-1.amazonaws.com/my-service:@Version
+        sleep 10
+        wget --retry-connrefused --tries=30 --wait=1 --timeout=1 -O - http://localhost:8080/health && SUCCESS=true || SUCCESS=false
+        /opt/aws/bin/cfn-signal --success ${SUCCESS} --stack @AWS::StackName --resource ASG --region @AWS::Region
+  ELB:
+    Type: AWS::ElasticLoadBalancing::LoadBalancer
+    Properties:
+      ConnectionDrainingPolicy:
+        Enabled: true
+        Timeout: 30
+      ConnectionSettings:
+        IdleTimeout: 60
+      CrossZone: false
+      HealthCheck:
+        HealthyThreshold: 2
+        Interval: 30
+        Target: HTTP:8080/health
+        Timeout: 5
+        UnhealthyThreshold: 3
+      LoadBalancerName: "@AWS::StackName"
+      Listeners:
+      - InstancePort: 8080
+        InstanceProtocol: HTTP
+        LoadBalancerPort: 80
+        Protocol: HTTP
+      - InstancePort: 8080
+        InstanceProtocol: HTTP
+        LoadBalancerPort: 443
+        Protocol: HTTPS
+        SSLCertificateId: arn:aws:iam::1234567800:server-certificate/service
+      Scheme: internet-facing
+      SecurityGroups:
+      - "@Environment[ELBSecurityGroup]"
+      Subnets: "@Environment[Subnets]"
+      Tags:
+      - Key: Name
+        Value: "@AWS::StackName"
+      - Key: Environment
+        Value: "@Environment"
+  ASG:
+    Type: AWS::AutoScaling::AutoScalingGroup
+    Properties:
+      AvailabilityZones: "@Environment[AvailabilityZones]"
+      Cooldown: 600
+      DesiredCapacity: 1
+      HealthCheckGracePeriod: 180
+      HealthCheckType: EC2
+      LaunchConfigurationName: "@LaunchConfig"
+      LoadBalancerNames:
+      - "@ELB"
+      MaxSize: 2
+      MinSize: 0
+      Tags:
+      - Key: Name
+        Value: "@AWS::StackName"
+        PropagateAtLaunch: true
+      - Key: Environment
+        Value: "@Environment"
+        PropagateAtLaunch: true
+      VPCZoneIdentifier: "@Environment[Subnets]"
+    UpdatePolicy:
+      AutoScalingRollingUpdate:
+        MinInstancesInService: 1
+        MaxBatchSize: 2
+        PauseTime: PT4M0S
+        WaitOnResourceSignals: true
+  R53Dns:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      AliasTarget:
+        DNSName:
+          Fn::GetAtt:
+          - ELB
+          - CanonicalHostedZoneName
+        HostedZoneId:
+          Fn::GetAtt:
+          - ELB
+          - CanonicalHostedZoneNameID
+      Comment: "@AWS::StackName"
+      HostedZoneName: myorg.net.
+      Name: "@Environment[DomainName]"
+      Type: A
+```

--- a/lib/autostacker24/template_preprocessor.rb
+++ b/lib/autostacker24/template_preprocessor.rb
@@ -50,7 +50,7 @@ module AutoStacker24
     def self.preprocess_user_data(s)
       m = /^@file:\/\/(.*)/.match(s)
       s = File.read(m[1]) if m
-      {'Fn::Base64' => s}
+      {'Fn::Base64' => preprocess_string(s)}
     end
 
     def self.preprocess_string(s)

--- a/lib/autostacker24/template_preprocessor.rb
+++ b/lib/autostacker24/template_preprocessor.rb
@@ -48,7 +48,7 @@ module AutoStacker24
     end
 
     def self.preprocess_user_data(s)
-      m = /^@file:\/\/(.*)/.match(s)
+      m = /\A@file:\/\/(.*)/.match(s)
       s = File.read(m[1]) if m
       {'Fn::Base64' => preprocess_string(s)}
     end
@@ -58,7 +58,7 @@ module AutoStacker24
         case token
           when '@@' then '@'
           when '@[' then '['
-          when /^@/ then parse_ref(token)
+          when /\A@/ then parse_ref(token)
           else token
         end
       end
@@ -81,7 +81,7 @@ module AutoStacker24
     end
 
     def self.parse_ref(token)
-      m = /^@([^\[]*)(\[([^,]*)(\s*,\s*(.*))?\])?$/.match(token)
+      m = /\A@([^\[]*)(\[([^,]*)(\s*,\s*(.*))?\])?$/.match(token)
       m1 = m[1]
       m2 = m[3]
       m3 = m[5]

--- a/lib/autostacker24/template_preprocessor.rb
+++ b/lib/autostacker24/template_preprocessor.rb
@@ -1,16 +1,20 @@
 
 require 'json'
 require 'set'
+require 'yaml'
 
 module AutoStacker24
 
   module Preprocessor
 
     def self.preprocess(template)
-      if template =~ /^\s*\/{2}\s*/i
-        template = preprocess_json(parse_json(template)).to_json
+      if template =~ /\A\s*\{/
+        template
+      elsif template =~ /\A\s*\/{2}/
+        preprocess_json(parse_json(template)).to_json
+      else
+        preprocess_json(parse_yaml(template)).to_json
       end
-      template
     end
 
     def self.parse_json(template)
@@ -19,6 +23,10 @@ module AutoStacker24
       require 'json/pure' # pure ruby parser has better error diagnostics
       JSON(template)
       raise e
+    end
+
+    def self.parse_yaml(template)
+      YAML.load(template)
     end
 
     def self.preprocess_json(json)

--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,7 @@ It is a thin wrapper around the
 [AWS Ruby SDK](http://docs.aws.amazon.com/AWSRubySDK/latest/frames.html).
 It lets you write simple and convenient automation scripts,
 especially if you have lots of parameters or dependencies between stacks.
-You can use it directly from Ruby code or as a command line tool.
+You can use it directly from Ruby code or from the command line.
 It enhances CloudFormation templates by parameter expansion in strings and
 it is even possible to write templates in [YAML](examples/yaml-stack.md) which is much friendlier
 to humans than JSON.
@@ -120,7 +120,7 @@ To Validate a template:
 $ autostacker24 validate --template /path/to/template.json
 ```
 
-To see the outcome after AutoStacker preprocessed your template;
+To see the outcome after AutoStacker24 preprocessed your template;
 
 ```
 $ autostacker24 preprocess --template /path/to/template.json

--- a/spec/example_script.sh
+++ b/spec/example_script.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-echo "test"
+echo "@Version"

--- a/spec/templating_spec.rb
+++ b/spec/templating_spec.rb
@@ -81,7 +81,8 @@ RSpec.describe 'Stacker Template Processing' do
   end
 
   it 'includes a user script with newlines' do
-    expect(parsed_template['file_include']['UserData']).to eq('Fn::Base64' => "#!/bin/bash\n\necho \"test\"\n")
+    user_data = {'Fn::Join' =>['', ["#!/bin/bash\n\necho \"", {'Ref' => 'Version'}, "\"\n"]]}
+    expect(parsed_template['file_include']['UserData']).to eq('Fn::Base64' => user_data)
   end
 
   it 'wraps userData in a Base64 encoded block' do

--- a/spec/yaml_spec.rb
+++ b/spec/yaml_spec.rb
@@ -1,0 +1,49 @@
+require 'spec_helper'
+require 'yaml'
+
+
+RSpec.describe 'YAML to JSON' do
+
+  let(:template) do
+    <<-EOL
+    # AutoStacker24 enabled CloudFormation template
+    AWSTemplateFormatVersion: "2010-09-09"
+    Description: My Stack
+    Parameters:
+      Environment: # Some Comments
+        Type: "String"
+        AllowedValues:
+          - Staging
+          - Production
+      DBName:
+        Type: String
+        Default: my-db
+        Priority: 5
+    Data: |
+      some very long
+      text splitted over
+      lines
+    UserData: bla
+    EOL
+  end
+
+  subject(:parsed_template) do
+    JSON.parse(Stacker.template_body(template))
+  end
+
+  it 'can read strings' do
+    expect(parsed_template['Description']).to eq('My Stack')
+  end
+
+  it 'can read arrays' do
+    expect(parsed_template['Parameters']['Environment']['AllowedValues']).to eq(%w(Staging Production))
+  end
+
+  it 'can read integers' do
+    expect(parsed_template['Parameters']['DBName']['Priority']).to eq(5)
+  end
+
+  it 'can read long text' do
+    expect(parsed_template['Data']).to eq("some very long\ntext splitted over\nlines\n")
+  end
+end


### PR DESCRIPTION
This is my proposal for Issue #6
As YAML and JSON are structurally almost identical it is very easy to convert YAML to JSON and vice versa. After merging this pull request you can write your CloudFormation template in YAML!

Editing YAML files is a lot easier than editing big JSON files. No more missing commas :-) 

To help converting existing templates, you can use this ruby script
```ruby
require 'json'
require 'yaml'
json = JSON.parse(File.read('my-template.json'))
File.write('my-template.yaml', json.to_yaml)
```

If this pull request gets merged a intend to add an `--yaml` option to the CLI so that you could use the `preprocess` command to show yaml. I also want to add a 'convert' command that could be used to convert snippets from the AWS doku to yaml snippets.

