### PR TITLE
Add explicit license 

### DIFF
--- a/autostacker24.gemspec
+++ b/autostacker24.gemspec
@@ -11,14 +11,16 @@ Gem::Specification.new do |s|
   s.summary        = 'Library for managing AWS CloudFormation stacks'
   s.description    = 'n/a'
   s.license        = 'MIT'
-  s.files         = `git ls-files lib -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  s.files          = `git ls-files lib -z`.split("\x0") << 'license.txt'
   s.version        = "1.0.#{MINOR_VERSION}"
-  s.executables    = ["autostacker24"]
+  s.executables    = ['autostacker24']
   s.add_dependency 'aws-sdk-core', '~> 2'
   s.add_dependency 'json', '~> 1.8'
   s.add_dependency 'json_pure', '~> 1.8'
   s.add_development_dependency 'rubocop', '~> 0.37.0'
-  s.add_development_dependency "rake", "~> 10.0"
+  s.add_development_dependency 'rake', '~> 10.0'
   s.add_development_dependency 'rspec', '~> 3.4'
+
+  puts s.files
 
 end

--- a/license.txt
+++ b/license.txt
@@ -1,0 +1,26 @@
+
+This software consists of voluntary contributions made by many
+individuals. For exact contribution history, see the revision history
+available at https://github.com/AutoScout24/autostacker24
+
+The MIT License (MIT)
+
+Copyright (c) [2015] [AutoScout24 GmbH]
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/license.txt
+++ b/license.txt
@@ -1,11 +1,7 @@
 
-This software consists of voluntary contributions made by many
-individuals. For exact contribution history, see the revision history
-available at https://github.com/AutoScout24/autostacker24
-
 The MIT License (MIT)
 
-Copyright (c) [2015] [AutoScout24 GmbH]
+Copyright (c) 2015 AutoScout24 GmbH
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
The gem has currently the license 'MIT'. To make this more explicit please I added the MIT license text as this might be important for potential users of autostacker24.

Using software without any license could be dangerous:
http://www.gnu.org/licenses/license-list.en.html#NoLicense

To get more contributors and users we should be explicit about the license. 
