### PR TITLE
Enable file substitution everywhere

### DIFF
--- a/autostacker24.gemspec
+++ b/autostacker24.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'aws-sdk-core', '~> 2'
   s.add_dependency 'json', '~> 1.8'
   s.add_dependency 'json_pure', '~> 1.8'
-  s.add_development_dependency 'rubocop', '~> 0.37.0'
+  s.add_development_dependency 'rubocop', '~> 0.37'
   s.add_development_dependency "rake", "~> 10.0"
   s.add_development_dependency 'rspec', '~> 3.4'
 

--- a/lib/autostacker24/template_preprocessor.rb
+++ b/lib/autostacker24/template_preprocessor.rb
@@ -48,12 +48,12 @@ module AutoStacker24
     end
 
     def self.preprocess_user_data(s)
-      m = /\A@file:\/\/(.*)/.match(s)
-      s = File.read(m[1]) if m
       {'Fn::Base64' => preprocess_string(s)}
     end
 
     def self.preprocess_string(s)
+      m = /^@file:\/\/(.*)$/.match(s)
+      s = File.read(m[1]) if m
       parts = tokenize(s).map do |token|
         case token
           when '@@' then '@'

--- a/readme.md
+++ b/readme.md
@@ -77,6 +77,7 @@ It has support for comments and long embedded string documents which makes it is
   `"prop": {"Fn::Join":["-",[`<br/>`{"Ref":"AWS::StackName"},{"Ref":"tableName"},"test"`<br/>`]]}`|`"prop": "@AWS::StackName-@tableName-test"`
   `"prop": "bla@hullebulle.org"` | `"prop": "bla@@hullebulle.org"`
   `"UserData": {"Fn:Base64": ... }` | `"UserData": "@file://./myscript.sh"`
+  `"content": {"Fn::Join":["\n", [...]]` | `"content" : "@file://./myfile.txt"`
   `"prop": {"Fn::FindInMap": ["RegionMap", { "Ref" : "AWS::Region" }, "32"]` | `"@RegionMap[@Region, 32]"` or `"@Region[32]`
 
 By default, AutoStacker24 don't preprocess templates. If you want to use this functionality your must start your template with a comment:

--- a/spec/templating_spec.rb
+++ b/spec/templating_spec.rb
@@ -18,7 +18,8 @@ RSpec.describe 'Stacker Template Processing' do
       "content" : { "Fn::Join" : ["", ["[general]\\n", "state_file = /var/lib/awslogs/agent-state\\n", "\\n"]]},
       "single_colon": "@AWS::Stack:something@Other",
       "file_include": {
-        "UserData": "@file://./spec/example_script.sh"
+        "UserData": "@file://./spec/example_script.sh",
+        "NonUserData": "@file://./spec/example_script.sh"
       },
       "auto_encode": {
         "UserData": "auto encode"
@@ -32,64 +33,69 @@ RSpec.describe 'Stacker Template Processing' do
     EOL
   end
 
-  subject(:parsed_template) { JSON.parse(Stacker.template_body(template)) }
+  subject(:processed) { JSON.parse(Stacker.template_body(template)) }
 
   it 'generates Fn:FindInMap elements' do
     expected = { 'Fn::FindInMap' => ['EnvMap', { 'Ref' => 'Env' }, 'Key'] }
-    expect(parsed_template['find_in_map']).to eq(expected)
+    expect(processed['find_in_map']).to eq(expected)
   end
 
   it 'generates Fn:FindInMap elements by convention' do
     expected = { 'Fn::FindInMap' => ['EnvMap', { 'Ref' => 'Env' }, 'Key'] }
-    expect(parsed_template['find_in_map_convention']).to eq(expected)
+    expect(processed['find_in_map_convention']).to eq(expected)
   end
 
   it 'removes any comments into valid json' do
     begin
-      expect(parsed_template['bla']).to eq('bla')
-      expect(parsed_template['fasel']).to eq('//no comment')
+      expect(processed['bla']).to eq('bla')
+      expect(processed['fasel']).to eq('//no comment')
     rescue JSON::ParserError => e
       raise "unparsable JSON output: #{e.message}"
     end
   end
 
   it 'substitutes a single variable' do
-    expect(parsed_template['single']).to eq('Ref' => 'var1')
+    expect(processed['single']).to eq('Ref' => 'var1')
   end
 
   it 'replaces an embedded variable' do
     expected_join_hash = { 'Fn::Join' => ['', ['bla ', { 'Ref' => 'var2' }, ' ', { 'Ref' => 'bla2' }]] }
-    expect(parsed_template['embedded']).to eq(expected_join_hash)
+    expect(processed['embedded']).to eq(expected_join_hash)
   end
 
   it 'replaces variables in an array' do
-    expect(parsed_template['array']).to eq([{ 'Ref' => 'var2' }, { 'Ref' => 'var3' }])
+    expect(processed['array']).to eq([{ 'Ref' => 'var2' }, { 'Ref' => 'var3' }])
   end
 
   it 'does not replace an escaped @' do
-    expect(parsed_template['escape']).to eq('bla@bla.com')
+    expect(processed['escape']).to eq('bla@bla.com')
   end
 
   it 'preserves content' do
     expected_join_hash = { 'Fn::Join' => ['', ["[general]\n", "state_file = /var/lib/awslogs/agent-state\n", "\n"]] }
-    expect(parsed_template['content']).to eq(expected_join_hash)
+    expect(processed['content']).to eq(expected_join_hash)
   end
 
   it 'includes only double semicolon in variable name' do
     expected_join_hash = { 'Fn::Join' => ['', [{ 'Ref' => 'AWS::Stack' }, ':something', { 'Ref' => 'Other' }]] }
-    expect(parsed_template['single_colon']).to eq(expected_join_hash)
+    expect(processed['single_colon']).to eq(expected_join_hash)
   end
 
-  it 'includes a user script with newlines' do
+  it 'substitutes @file:// with file content' do
+    content = {'Fn::Join' =>['', ["#!/bin/bash\n\necho \"", {'Ref' => 'Version'}, "\"\n"]]}
+    expect(processed['file_include']['NonUserData']).to eq(content)
+  end
+
+  it 'substitutes @file:// in UserData with file content and encodes it in base64' do
     user_data = {'Fn::Join' =>['', ["#!/bin/bash\n\necho \"", {'Ref' => 'Version'}, "\"\n"]]}
-    expect(parsed_template['file_include']['UserData']).to eq('Fn::Base64' => user_data)
+    expect(processed['file_include']['UserData']).to eq('Fn::Base64' => user_data)
   end
 
   it 'wraps userData in a Base64 encoded block' do
-    expect(parsed_template['auto_encode']['UserData']).to eq('Fn::Base64' => 'auto encode')
+    expect(processed['auto_encode']['UserData']).to eq('Fn::Base64' => 'auto encode')
   end
 
   it 'does not double wrap encoded blocks' do
-    expect(parsed_template['already_encoded']['UserData']).to eq('Fn::Base64' => '#!/bin/bash')
+    expect(processed['already_encoded']['UserData']).to eq('Fn::Base64' => '#!/bin/bash')
   end
 end


### PR DESCRIPTION
This enables `"@file://myfile.txt"` strings to be replaced with the contents of myfile.txt and fixes #16
File content is preprocessed by the usual rules.
Note that only the complete string specifies the file and gets replaced with the file content. It will not work inside strings, so something like this is not allowed:
`"some text @file://myfile.txt some moretext"`
You can work around this limitation with Fn::Join again, but I don't believe that anyone will ever need this.