### PR TITLE
See output immediately in tools like Jenkins/TeamCity or Docker

### DIFF
--- a/lib/autostacker24/stacker.rb
+++ b/lib/autostacker24/stacker.rb
@@ -3,6 +3,10 @@ require 'set'
 
 require_relative 'template_preprocessor.rb'
 
+# disable buffering to stdout and stderr so we get immediate feedback if run by Jenkins/TeamCity/Docker
+STDOUT.sync = true
+STDERR.sync = true
+
 module Stacker
 
   attr_reader :region, :credentials


### PR DESCRIPTION
This pull requests disables buffering to stdout and stderr. This makes output generated by autostacker (especially when you are create/update a stack) immediately visible in build tools like Jenkins/TeamCity. Also helps or in docker logs or docker run without a tty.