### PR TITLE
fix incorrect regex for yaml detection

### DIFF
--- a/bin/autostacker24
+++ b/bin/autostacker24
@@ -73,7 +73,7 @@ case args.command
   when /convert/
     check_template(args)
     template = File.read(args.template)
-    if template =~ /\A(\s*\{)|(\s*\/{2})/
+    if template =~ /\A((\s*\{)|(\s*\/{2}))/
       puts JSON.parse(template).to_yaml.sub('---', '# AutoStacker24 CloudFormation YAML Template')
     else
       puts '// AutoStacker24 CloudFormation JSON Template '


### PR DESCRIPTION
The yaml detection for the CLI 'convert' command is not always correct, e.g. if you have embedded '//' in your yaml template it was detected as json and the 'convert' command failed.