### PR TITLE
separate cli commands show and process

### DIFF
--- a/bin/autostacker24
+++ b/bin/autostacker24
@@ -24,11 +24,12 @@ parser = OptionParser.new do |opts|
   opts.banner = 'Usage: autostacker24 command [options]'
   opts.separator ''
   opts.separator 'Commands:'
-  opts.separator "\tupdate\t\t create or update a stack"
-  opts.separator "\tdelete\t\t delete a stack"
-  opts.separator "\tprocess\t\t pretty print processed template"
-  opts.separator "\tvalidate\t validate the template"
-  opts.separator "\tconvert\t\t convert template to and from YAML"
+  opts.separator "\tupdate     create or update a stack"
+  opts.separator "\tdelete     delete a stack"
+  opts.separator "\tshow       show processed template with pretty printing"
+  opts.separator "\tprocess    print processed template"
+  opts.separator "\tvalidate   validate the template"
+  opts.separator "\tconvert    convert template to and from YAML"
   opts.separator ''
   opts.separator 'Options:'
   opts.on('--template TEMPLATE', 'Path to template')                {|v| args.template = v}
@@ -67,7 +68,10 @@ case args.command
   when /delete/
     check_stack(args)
     Stacker.delete_stack(args.stack)
-  when /process|show/
+  when /process/
+    check_template(args)
+    puts Stacker.template_body(args.template)
+  when /show/
     check_template(args)
     puts JSON.pretty_generate(JSON.parse(Stacker.template_body(args.template)))
   when /convert/

--- a/readme.md
+++ b/readme.md
@@ -156,10 +156,16 @@ To Validate a template:
 $ autostacker24 validate --template /path/to/template.json
 ```
 
-To see the outcome after AutoStacker24 preprocessed your template;
+To see the outcome after AutoStacker24 preprocessed your template as pretty printed json
 
 ```
 $ autostacker24 show --template /path/to/template.json
+```
+
+To see the outcome after AutoStacker24 preprocessed your template 
+
+```
+$ autostacker24 process --template /path/to/template.json
 ```
 
 To create or update a stack


### PR DESCRIPTION
Currently, `show` and `process` are aliases that preprocess a template and output a pretty printed json file.

This pull requests differentiates the two:

- `autostacker24 show --template my-stack.yaml` will preprocess the template and show the result pretty printed
- `autostacker24 process --template my-stack.yaml` will preprocess the template and output the result as it would be sent to CloudFormation (minified)

The latter one is useful if you integrate autostacker24 in a deployment pipeline that uploads the preprocessed template as one single artifact (including all referenced files).
