### PR TITLE
Optimize YAML detection

### DIFF
--- a/lib/autostacker24/template_preprocessor.rb
+++ b/lib/autostacker24/template_preprocessor.rb
@@ -8,12 +8,12 @@ module AutoStacker24
   module Preprocessor
 
     def self.preprocess(template)
-      if template =~ /\A\s*\{/
-        template
-      elsif template =~ /\A\s*\/{2}/
+      if template =~ /\A\s*\/{2}/
         preprocess_json(parse_json(template)).to_json
-      else
+      elsif template =~ /\A\s*#/
         preprocess_json(parse_yaml(template)).to_json
+      else
+        template
       end
     end
 

--- a/spec/yaml_spec.rb
+++ b/spec/yaml_spec.rb
@@ -2,6 +2,45 @@ require 'spec_helper'
 require 'yaml'
 
 
+RSpec.describe 'Keep YAML' do
+
+  let(:template) do
+    <<-EOL
+    AWSTemplateFormatVersion: "2010-09-09"
+    Description: My Stack
+    Parameters:
+      Environment: # Some Comments
+        Type: "String"
+        AllowedValues:
+          - Staging
+          - Production
+      DBName:
+        Type: String
+        Default: my-db
+        Priority: 5
+    Text: |
+      some very long
+      text splitted over
+      lines
+    StackName: !Ref AWS::StackName
+    UserData: |
+      #!/bin/bash
+      echo "@Environment"
+      exit 42
+    EOL
+  end
+
+  subject(:parsed) do
+    YAML.load(Stacker.template_body(template))
+  end
+
+  it 'does not manipulate the template' do
+    expect(parsed['UserData']).to eq("#!/bin/bash\necho \"@Environment\"\nexit 42\n")
+  end
+
+end
+
+
 RSpec.describe 'YAML to JSON' do
 
   let(:template) do


### PR DESCRIPTION
Like with JSON files, AutoStacker24 will now also differentiate between
YAML files which want to have the template preprocessing and those
who don't.

By adding a comment in the first line with `autostacker24` it enforces
the preprocessing. Without comment the file will not be manipulated.

This worked already fine for JSON files, now also YAML files gets the
same treatment.