### PR TITLE
Accept CloudFormation YAML short notation intrinsic functions

### DIFF
--- a/spec/yaml_spec.rb
+++ b/spec/yaml_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'yaml'
 
 
-RSpec.describe 'Keep YAML' do
+RSpec.describe "Don't preprocess if YAML has no starting comment" do
 
   let(:template) do
     <<-EOL
@@ -30,12 +30,82 @@ RSpec.describe 'Keep YAML' do
     EOL
   end
 
-  subject(:parsed) do
-    YAML.load(Stacker.template_body(template))
+  subject(:emitted) do
+    Stacker.template_body(template)
   end
 
   it 'does not manipulate the template' do
-    expect(parsed['UserData']).to eq("#!/bin/bash\necho \"@Environment\"\nexit 42\n")
+    expect(emitted).to eq(template)
+  end
+
+end
+
+RSpec.describe "CloudFormation YAML short intrinsic function tag" do
+
+  let(:template) do
+    <<-EOL
+    # AutoStacker24 enabled CloudFormation template
+    Parameters:
+      Environment: # Some Comments
+        Type: String
+        Default: Staging
+    StringInterpolation: "@Environment"
+    Base64: !Base64 "valueToEncode"
+    FindInMap: !FindInMap [ MapName, TopLevelKey, SecondLevelKey ]
+    GetAZs: !GetAZs eu-west-1
+    GetAtt: !GetAtt resource.attributeName
+    ImportValue: !ImportValue sharedValueToImport
+    Join: !Join [ " ", [ one, two, three ] ]
+    Select: !Select [ "1", [ "apples", "grapes", "oranges" ] ]
+    Sub: !Sub
+      - String
+      - { Var1Name: Var1Value, Var2Name: Var2Value }
+    Ref: !Ref AWS::StackName
+    EOL
+  end
+
+  subject(:processed) do
+    JSON(Stacker.template_body(template))
+  end
+
+  it 'still interpolates autostacker strings' do
+    expect(processed['StringInterpolation']).to eq('Ref' => 'Environment')
+  end
+
+  it '!Base64' do
+    expect(processed['Base64']).to eq('Fn::Base64' => 'valueToEncode' )
+  end
+
+  it '!FindInMap' do
+    expect(processed['FindInMap']).to eq('Fn::FindInMap' => ['MapName', 'TopLevelKey', 'SecondLevelKey'])
+  end
+
+  it '!GetAZs' do
+    expect(processed['GetAZs']).to eq('Fn::GetAZs' => 'eu-west-1' )
+  end
+
+  it '!GetAtt resource.attributeName' do
+    expect(processed['GetAtt']).to eq('Fn::GetAtt' => ['resource', 'attributeName'])
+  end
+
+  it '!ImportValue' do
+    expect(processed['ImportValue']).to eq('Fn::ImportValue' => 'sharedValueToImport')
+  end
+
+  it '!Join' do
+    expect(processed['Join']).to eq('Fn::Join' => [" ", ['one', 'two', 'three']])
+  end
+
+  it '!Select' do
+    expect(processed['Select']).to eq('Fn::Select' =>  ['1', ['apples', 'grapes', 'oranges']])
+  end
+
+  it '!Sub' do
+    expect(processed['Sub']).to eq('Fn::Sub' => ['String', { 'Var1Name' => 'Var1Value', 'Var2Name' => 'Var2Value' }])
+  end
+
+  it '!Ref' do
+    expect(processed['Ref']).to eq('Ref' => 'AWS::StackName')
   end
 
 end


### PR DESCRIPTION
closes #35 

This pull request adds the ability to read YAML tags and convert them to CloudFormation intrinsic functions. Your can now use CloudFormations new short syntax for intrinsic functions in YAML templates.

As the short tag based short notation is not canonical special handling for `Fn:GetAtt` and `Ref` was necessary. If new functions follow the rule of `!Tag Args -> {"Fn::Tag" : Args}` no changes to AutoStacker24. If AWS again creates an exception from this rule AutoStacker code must be changed.