### PR TITLE
Fix relative file includes

### DIFF
--- a/lib/autostacker24/stacker.rb
+++ b/lib/autostacker24/stacker.rb
@@ -182,8 +182,14 @@ module Stacker
   end
 
   def template_body(template)
-    template = File.read(template) if File.exists?(template)
+    wd = Dir.getwd()
+    if File.exists?(template) # template is a valid filename
+      template = File.read(template)
+      Dir.chdir(File.dirname(template))
+    end
     AutoStacker24::Preprocessor.preprocess(template)
+  ensure
+    Dir.chdir(wd)
   end
 
   extend self

--- a/lib/autostacker24/template_preprocessor.rb
+++ b/lib/autostacker24/template_preprocessor.rb
@@ -111,13 +111,9 @@ module AutoStacker24
         i = s.index('@', i + 1)
         return s, '' if i.nil?
 
-        file_match = /\A@file:\/\/([^@\s]+)@?/.match(s[i..-1])
-        file_curly_match = /\A@\{file:\/\/([^\}]+)\}/.match(s[i..-1])
+        file_match = /\A@file:\/\/([^@\s]+)@?/.match(s[i..-1]) || /\A@\{file:\/\/([^\}]+)\}/.match(s[i..-1])
         if file_match # inline file
           s = s[0, i] + File.read(file_match[1]) + file_match.post_match
-          i -= 1
-        elsif file_curly_match # inline file with curly braces
-          s = s[0, i] + File.read(file_curly_match[1]) + file_curly_match.post_match
           i -= 1
         elsif s[i, 2] =~ /\A@@/ # escape
           s = s[0, i] + s[i+1..-1]


### PR DESCRIPTION
Given a template living in `~/project/stack.yaml` which includes script.sh the file path should be relative to the directory where the template is living, not the current working dir.

Examples:

`@file://./script.sh` should include `~/project/script.sh`
`@file://../script.sh` should include `~/script.sh`
`@file:///script.sh` should include `/script.sh`
