### PR TITLE
Use ENV['AWS_SHARED_CREDENTIALS_FILE'] (see:

### DIFF
--- a/bin/autostacker24
+++ b/bin/autostacker24
@@ -66,7 +66,7 @@ args.command = ARGV[0]
 args.params = args.params.inject({}){|m, kv| m.merge(Hash[kv[0].to_sym, kv[1]])}
 
 Stacker.region = args.region
-Stacker.credentials = Aws::SharedCredentials.new(profile_name: args.profile) if args.profile
+Stacker.credentials = Aws::SharedCredentials.new(profile_name: args.profile, path: ENV['AWS_SHARED_CREDENTIALS_FILE']) if args.profile || ENV['AWS_SHARED_CREDENTIALS_FILE']
 
 case args.command
   when /validate/


### PR DESCRIPTION
Use ENV['AWS_SHARED_CREDENTIALS_FILE'] (see http://docs.aws.amazon.com/cli/latest/topic/config-vars.html#the-shared-credentials-file)
from the awscli to read the credentials from another file than default
(~/.aws/credentials). This is useful when you temporarely write
credentials files to the file system end clean them up later (eg on ci
systems)