### PR TITLE
autostacker24 depends only on aws-sdk-cloudformation

### DIFF
--- a/autostacker24.gemspec
+++ b/autostacker24.gemspec
@@ -20,7 +20,4 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rubocop', '~> 0.49'
   s.add_development_dependency 'rake', '~> 12'
   s.add_development_dependency 'rspec', '~> 3'
-
-  puts s.files
-
 end

--- a/autostacker24.gemspec
+++ b/autostacker24.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.version        = "2.8.0"
   s.executables    = ['autostacker24']
 
-  s.add_dependency 'aws-sdk', '~> 3'
+  s.add_dependency 'aws-sdk-cloudformation', '~> 1'
   s.add_dependency 'json', '~> 2'
   s.add_dependency 'json_pure', '~> 2'
 

--- a/lib/autostacker24/stacker.rb
+++ b/lib/autostacker24/stacker.rb
@@ -1,4 +1,4 @@
-require 'aws-sdk-core'
+require 'aws-sdk-cloudformation'
 require 'set'
 
 require_relative 'template_preprocessor.rb'


### PR DESCRIPTION
* As this gem depends only on aws-sdk-cloudformation, there is no need to download all the gems that belong to "aws-sdk".
* Fixed broken `require` statement (details are here: https://github.com/aws/aws-sdk-ruby#upgrade-from-version-2)