### PR TITLE
Support role based profiles like the aws cli does

### DIFF
--- a/autostacker24.gemspec
+++ b/autostacker24.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.description    = 'AutoStacker24 is a small ruby gem for managing AWS CloudFormation stacks. It is a thin wrapper around the AWS Ruby SDK. It lets you write simple and convenient automation scripts, especially if you have lots of parameters or dependencies between stacks. You can use it directly from Ruby code or from the command line. It enhances CloudFormation templates by parameter expansion in strings and it is even possible to write templates in YAML which is much friendlier to humans than JSON. You can use autostacker24 cli to convert existing templates to YAML.'
   s.license        = 'MIT'
   s.files          = `git ls-files lib -z`.split("\x0") << 'license.txt'
-  s.version        = "2.8.6"
+  s.version        = "2.8.7"
   s.executables    = ['autostacker24']
 
   s.add_dependency 'aws-sdk-cloudformation', '~> 1'

--- a/autostacker24.gemspec
+++ b/autostacker24.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.description    = 'AutoStacker24 is a small ruby gem for managing AWS CloudFormation stacks. It is a thin wrapper around the AWS Ruby SDK. It lets you write simple and convenient automation scripts, especially if you have lots of parameters or dependencies between stacks. You can use it directly from Ruby code or from the command line. It enhances CloudFormation templates by parameter expansion in strings and it is even possible to write templates in YAML which is much friendlier to humans than JSON. You can use autostacker24 cli to convert existing templates to YAML.'
   s.license        = 'MIT'
   s.files          = `git ls-files lib -z`.split("\x0") << 'license.txt'
-  s.version        = "2.8.7"
+  s.version        = "2.9.1"
   s.executables    = ['autostacker24']
 
   s.add_dependency 'aws-sdk-cloudformation', '~> 1'

--- a/bin/autostacker24
+++ b/bin/autostacker24
@@ -77,7 +77,7 @@ args.command = ARGV[0]
 args.params = args.params.inject({}){|m, kv| m.merge(Hash[kv[0].to_sym, kv[1]])}
 
 Stacker.region = args.region
-Stacker.credentials = Aws::SharedCredentials.new(profile_name: args.profile, path: ENV['AWS_SHARED_CREDENTIALS_FILE']) if args.profile || ENV['AWS_SHARED_CREDENTIALS_FILE']
+Stacker.profile = args.profile
 
 case args.command
   when /validate/

--- a/lib/autostacker24/stacker.rb
+++ b/lib/autostacker24/stacker.rb
@@ -11,17 +11,16 @@ DEFAULT_TIMEOUT = 60
 
 module Stacker
 
-  attr_reader :region, :credentials
+  attr_reader :region, :profile
 
-  # use ENV['AWS_ACCESS_KEY_ID'] and ENV['AWS_SECRET_ACCESS_KEY'] if you don't want to set credentials by code
-  def credentials=(credentials)
-    unless credentials == @credentials
+  def profile=(profile)
+    unless profile == @profile
       @lazy_cloud_formation = nil
-      @credentials = credentials
+      @profile = profile
     end
   end
 
-  def region=(region) # use ENV['AWS_REGION'] or ENV['AWS_DEFAULT_REGION']
+  def region=(region)
     unless region == @region
       @lazy_cloud_formation = nil
       @region = region
@@ -205,7 +204,7 @@ module Stacker
   def cloud_formation # lazy CloudFormation client
     unless @lazy_cloud_formation
       params = @cloud_formation_params || {}
-      params[:credentials] = @credentials if @credentials
+      params[:profile] = @profile if @profile
       params[:region] = @region if @region
       params[:retry_limit] = 10
       @lazy_cloud_formation = Aws::CloudFormation::Client.new(params)

--- a/lib/autostacker24/stacker.rb
+++ b/lib/autostacker24/stacker.rb
@@ -11,12 +11,19 @@ DEFAULT_TIMEOUT = 60
 
 module Stacker
 
-  attr_reader :region, :profile
+  attr_reader :region, :credentials, :profile
 
   def profile=(profile)
     unless profile == @profile
       @lazy_cloud_formation = nil
       @profile = profile
+    end
+  end
+
+  def credentials=(credentials)
+    unless credentials == @credentials
+      @lazy_cloud_formation = nil
+      @credentials = credentials
     end
   end
 
@@ -205,6 +212,7 @@ module Stacker
     unless @lazy_cloud_formation
       params = @cloud_formation_params || {}
       params[:profile] = @profile if @profile
+      params[:credentials] = @credentials if @credentials
       params[:region] = @region if @region
       params[:retry_limit] = 10
       @lazy_cloud_formation = Aws::CloudFormation::Client.new(params)

--- a/readme.md
+++ b/readme.md
@@ -28,7 +28,7 @@ It will also wait until the stack operation is eventually finished, handling all
   - `parent_stack_name`: this special feature will read the output parameters of an existing stack and
     merge them to the given parameters. Therefore the new stack can easily reference resources
     (e.g. VPC Ids or Security Groups) from a parent stack.
-  - `tags`: Key-value pairs to associate with this stack. As CloudFormation [does not support updating tags](http://docs.aws.amazon.com/cli/latest/reference/cloudformation/update-stack.html) AutoStacker24 is injecting the tags to all  `Resources` elements which support it.
+  - `tags`: Key-value pairs to associate with this stack. As CloudFormation [does not support updating tags](http://docs.aws.amazon.com/cli/latest/reference/cloudformation/update-stack.html) AutoStacker24 is injecting the tags to all `Resources` elements which support it.
 
 Example:
 
@@ -162,7 +162,7 @@ To see the outcome after AutoStacker24 preprocessed your template as pretty prin
 $ autostacker24 show --template /path/to/template.json
 ```
 
-To see the outcome after AutoStacker24 preprocessed your template 
+To see the outcome after AutoStacker24 preprocessed your template
 
 ```
 $ autostacker24 process --template /path/to/template.json
@@ -192,3 +192,10 @@ To create or update a stack and add tags from tags file (can be json or yaml) to
 ```
 $ autostacker24 update --stack MyStack --template /path/to/template.yaml --tags /path/to/tags.json
 ```
+
+AutoStacker24 supports the usual AWS SDK environment variables like
+- AWS_ACCESS_KEY_ID
+- AWS_SECRET_ACCESS_KEY
+- AWS_SHARED_CREDENTIALS_FILE
+- AWS_PROFILE
+- AWS_REGION and AWS_DEFAULT_REGION


### PR DESCRIPTION
You can put role based profiles in you `~/.aws/config` file like this:
```
[profile atombrenner]
...
[profile my-lab]
role_arn = arn:aws:iam::882778913465:role/OrganizationAccountAccessRole
source_profile = atombrenner
```
You can do something like this with `aws ec2 describe-instances --profile my-lab`. Unfortunately this currently does not work with autostacker24 because the profile is not passed to the client and the provided role is not assumed.

With this PR role based profiles work as expected.